### PR TITLE
fix: plan instruction formatting inconsistency (2)

### DIFF
--- a/src/routes/plan/selection/+page.svelte
+++ b/src/routes/plan/selection/+page.svelte
@@ -23,9 +23,12 @@
   // strips the inline html the API returns, so the markup below is the only thing @html renders
   const domParser = new DOMParser();
   const format = (s: string) =>
-    (domParser.parseFromString(s, 'text/html').body.textContent ?? '')
-      .replaceAll(/(\d\))([a-zA-Z])/g, '$1<br>$2') //insert line break (not always present)
-      .replaceAll(/((?:[A-Z][\w.'-]*)(?: [A-Z][\w.'-]*)*)\s*\(ID:\s*\d+\)/g, '<b>$1</b>'); //bold the stop name, drop its id
+    (
+      domParser.parseFromString(s.replaceAll(/\(ID: \d+\)/g, '!br!'), 'text/html').body
+        .textContent ?? ''
+    )
+      .replaceAll(/!br!/g, '<br>')
+      .replaceAll(/(My Location)/g, '$1<br>');
 
   const plan = $derived(planManager.selectedPlan);
   const instructions = $derived(plan?.instructions ?? []);

--- a/src/routes/plan/selection/+page.svelte
+++ b/src/routes/plan/selection/+page.svelte
@@ -28,7 +28,8 @@
         .textContent ?? ''
     )
       .replaceAll(/!br!/g, '<br>')
-      .replaceAll(/(My Location)/g, '$1<br>');
+      .replaceAll(/(My Location)/g, '$1<br>')
+      .replace(/(<br>)*$/, '');
 
   const plan = $derived(planManager.selectedPlan);
   const instructions = $derived(plan?.instructions ?? []);


### PR DESCRIPTION
reverted changes committed to route-caching and created a fix here.

bolding inconsistent on multi-line instruction blobs, and no line break on My Location -> (next instruction)
both fixed here